### PR TITLE
Replace LCD to RPC 

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -30,9 +30,7 @@ type Mantle struct {
 }
 
 type SyncConfiguration struct {
-	LCDLatestBlockEndpoint string
-	LCDBlockEndpoint       string
-	TendermintEndpoint     string
+	TendermintEndpoint string
 }
 
 func NewMantle(
@@ -84,7 +82,7 @@ func NewMantle(
 }
 
 func (mantle *Mantle) QuerySync(configuration SyncConfiguration, currentBlockHeight int64) {
-	remoteBlock, err := subscriber.GetBlockLCD(configuration.LCDLatestBlockEndpoint)
+	remoteBlock, err := subscriber.GetBlock(fmt.Sprintf("http://%s/block", configuration.TendermintEndpoint))
 
 	if err != nil {
 		panic(fmt.Errorf("error during mantle sync: remote head fetch failed. fromHeight=%d, (%s)", currentBlockHeight, err))
@@ -92,25 +90,30 @@ func (mantle *Mantle) QuerySync(configuration SyncConfiguration, currentBlockHei
 
 	remoteHeight := remoteBlock.Header.Height
 	syncingBlockHeight := currentBlockHeight
+	tStart := time.Now()
 
-	for syncingBlockHeight < remoteHeight {
-		remoteBlock, err := subscriber.GetBlockLCD(fmt.Sprintf(configuration.LCDBlockEndpoint, syncingBlockHeight+1))
+	for syncingBlockHeight < remoteHeight && syncingBlockHeight < 1000 {
+		remoteBlock, err := subscriber.GetBlock(fmt.Sprintf("http://%s/block?height=%d", configuration.TendermintEndpoint, syncingBlockHeight+1))
 		if err != nil {
 			panic(fmt.Errorf("error during mantle sync: remote block(%d) fetch failed", syncingBlockHeight))
 		}
-
-		log.Printf("[mantle] Syncing block(%d)", remoteBlock.Header.Height)
 
 		// run round
 		mantle.Inject(remoteBlock)
 
 		syncingBlockHeight++
 	}
+
+	dur := time.Now().Sub(tStart)
+
+	if dur > time.Second {
+		log.Printf("[mantle] total spent time: %dms", dur.Milliseconds())
+	}
 }
 
 func (mantle *Mantle) Sync(configuration SyncConfiguration) {
 	// subscribe to NewBlock event
-	rpcSubscription := subscriber.NewRpcSubscription(configuration.TendermintEndpoint)
+	rpcSubscription := subscriber.NewRpcSubscription(fmt.Sprintf("ws://%s/websocket", configuration.TendermintEndpoint))
 	blockChannel := rpcSubscription.Subscribe()
 
 	for {
@@ -119,7 +122,7 @@ func (mantle *Mantle) Sync(configuration SyncConfiguration) {
 			lastBlockHeight := mantle.app.GetApp().LastBlockHeight()
 
 			if block.Header.Height-lastBlockHeight != 1 {
-				log.Printf("[mantle] SyncByRPC mine: %d, chain: %d", lastBlockHeight, block.Header.Height)
+				log.Printf("[mantle] QuerySync started %d to %d", lastBlockHeight, block.Header.Height)
 				mantle.QuerySync(configuration, lastBlockHeight)
 			} else {
 				mantle.Inject(&block)

--- a/app/app.go
+++ b/app/app.go
@@ -92,7 +92,7 @@ func (mantle *Mantle) QuerySync(configuration SyncConfiguration, currentBlockHei
 	syncingBlockHeight := currentBlockHeight
 	tStart := time.Now()
 
-	for syncingBlockHeight < remoteHeight && syncingBlockHeight < 1000 {
+	for syncingBlockHeight < remoteHeight {
 		remoteBlock, err := subscriber.GetBlock(fmt.Sprintf("http://%s/block?height=%d", configuration.TendermintEndpoint, syncingBlockHeight+1))
 		if err != nil {
 			panic(fmt.Errorf("error during mantle sync: remote block(%d) fetch failed", syncingBlockHeight))
@@ -107,7 +107,7 @@ func (mantle *Mantle) QuerySync(configuration SyncConfiguration, currentBlockHei
 	dur := time.Now().Sub(tStart)
 
 	if dur > time.Second {
-		log.Printf("[mantle] total spent time: %dms", dur.Milliseconds())
+		log.Printf("[mantle] QuerySync: %d to %d, Elapsed: %dms", currentBlockHeight, remoteHeight, dur.Milliseconds())
 	}
 }
 
@@ -122,7 +122,6 @@ func (mantle *Mantle) Sync(configuration SyncConfiguration) {
 			lastBlockHeight := mantle.app.GetApp().LastBlockHeight()
 
 			if block.Header.Height-lastBlockHeight != 1 {
-				log.Printf("[mantle] QuerySync started %d to %d", lastBlockHeight, block.Header.Height)
 				mantle.QuerySync(configuration, lastBlockHeight)
 			} else {
 				mantle.Inject(&block)

--- a/subscriber/http.go
+++ b/subscriber/http.go
@@ -3,14 +3,15 @@ package subscriber
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/terra-project/mantle/types"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/terra-project/mantle/types"
 )
 
 type BlockGetter func(height interface{}) (*types.Block, error)
 
-func GetBlockLCD(endpoint string) (*types.Block, error) {
+func GetBlock(endpoint string) (*types.Block, error) {
 	res, err := http.Get(endpoint)
 	if err != nil {
 		return nil, err
@@ -21,14 +22,20 @@ func GetBlockLCD(endpoint string) (*types.Block, error) {
 		return nil, err
 	}
 
-	temp := map[string]json.RawMessage{}
-	if err := json.Unmarshal(resbytes, &temp); err != nil {
-		return nil, err
+	data := new(struct {
+		Result struct {
+			Block json.RawMessage
+		} `json:"result"`
+	})
+
+	if unmarshalErr := json.Unmarshal(resbytes, data); unmarshalErr != nil {
+		panic(unmarshalErr)
 	}
 
 	block := types.Block{}
-	if err := json.Unmarshal(temp["block"], &block); err != nil {
-		return nil, err
+
+	if err := json.Unmarshal(data.Result.Block, &block); err != nil {
+		panic(err)
 	}
 
 	return &block, nil

--- a/utils/responses.go
+++ b/utils/responses.go
@@ -1,26 +1,12 @@
 package utils
 
 import (
-	"encoding/json"
-	"fmt"
 	"strconv"
 	"time"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/terra-project/mantle/types"
 )
-
-func UnmarshalBlockResponseFromLCD(blockResponse []byte, target *types.Block) {
-	tmp := make(map[string]json.RawMessage)
-
-	if err := json.Unmarshal(blockResponse, &tmp); err != nil {
-		panic(fmt.Sprintf("Error while converting block: %s", err))
-	}
-
-	if err := json.Unmarshal(tmp["block"], &target); err != nil {
-		panic("Error during UnmarshalBlockResponseFromLCD")
-	}
-}
 
 func ConvertToABCIHeader(header *types.Header) abci.Header {
 	var abciHeader = abci.Header{}


### PR DESCRIPTION
## Changes
* Removed LCDBlockEndpoint and LCDLatestBlockEndpoint from SyncConfiguration
* TendermintEndpoint syntax changed to `<host>:<port>` i.e. `localhost:26657`
